### PR TITLE
Fix #1

### DIFF
--- a/Assets/UXF/Scripts/UI/ParticipantListSelection.cs
+++ b/Assets/UXF/Scripts/UI/ParticipantListSelection.cs
@@ -209,9 +209,20 @@ namespace UXF
             // if we have new participant selected, we need to create it in the pplist
             if (participantSelector.IsNewSelected())
             {
-                // add new participant to list
-                row = ppList.NewRow();
-                ppList.Rows.Add(row);
+                // if new participant is given an id that exists in pplist, throw error
+                DataRow searchResultRow = ppList.AsEnumerable().SingleOrDefault(r => r.Field<string>("ppid") == ppid);
+                if (searchResultRow != null)
+                {
+                    form.ppidElement.controller.DisplayFault();
+                    throw new Exception("Participant ID already exists! Enter a new ID or select the existing participant from the dropdown.");
+                }
+                // else new id has been entered
+                else
+                {
+                    // add new participant to list
+                    row = ppList.NewRow();
+                    ppList.Rows.Add(row);
+                }
             }
             // else we update the row with any changes we made in the form
             else 


### PR DESCRIPTION
- Problem may have been due to AsEnumerable().Single(...), now using AsEnumerable().SingleOrDefault(...) in the query

- Throw appropriate error (in UI and as an Exception) when duplicate key is added with New Participant selected

- Passes all test in Unity 2017.4