### PR TITLE
Raise exception on new column while updating datapoint

### DIFF
--- a/Assets/UXF/Scripts/UI/ParticipantListSelection.cs
+++ b/Assets/UXF/Scripts/UI/ParticipantListSelection.cs
@@ -247,7 +247,7 @@ namespace UXF
 
             // update row in table
             foreach (var keyValuePair in completedForm)
-                row[keyValuePair.Key] = keyValuePair.Value;     
+                UpdateDatapoint(row, keyValuePair.Key, keyValuePair.Value);    
 
             // write pplist
             CommitCSV();
@@ -255,10 +255,8 @@ namespace UXF
 
         }
 
-        public void UpdateDatapoint(string ppid, string datapointName, object value)
-        {
-            DataRow row = ppList.AsEnumerable().Single(r => r.Field<string>("ppid") == ppid);
-            
+        public void UpdateDatapoint(DataRow row, string datapointName, object value)
+        {           
             try
             {
                 row[datapointName] = value;


### PR DESCRIPTION
- Using existing (but unused) helper method to raise exception whenever new column encountered while updating a datapoint
- Changed method definition to take a DataRow instead of ppid string since row fetched is different in different conditions
- Passes all tests in Unity 2017.4