### PR TITLE
Add optional message to faults

### DIFF
--- a/Assets/UXF/Scripts/UI/Form/FormElementController.cs
+++ b/Assets/UXF/Scripts/UI/Form/FormElementController.cs
@@ -85,6 +85,12 @@ namespace UXF
             Invoke("ResetTitle", 5);
         }
 
+        public void DisplayFault(string message)
+        {
+            title.text = string.Format("{0} <b><color=red>(!) Error: {1}</color></b>", originalTitle, message);
+            Invoke("ResetTitle", 8);
+        }
+
         public void ResetTitle()
         {
             title.text = originalTitle;

--- a/Assets/UXF/Scripts/UI/ParticipantListSelection.cs
+++ b/Assets/UXF/Scripts/UI/ParticipantListSelection.cs
@@ -214,7 +214,7 @@ namespace UXF
             // check if not empty
             if (ppid.Replace(" ", string.Empty) == string.Empty)
             {
-                form.ppidElement.controller.DisplayFault();
+                form.ppidElement.controller.DisplayFault("Invalid participant name!");
                 throw new Exception("Invalid participant name!");
             }
 
@@ -226,7 +226,7 @@ namespace UXF
                 DataRow searchResultRow = ppList.AsEnumerable().FirstOrDefault(r => r.Field<string>("ppid") == ppid);
                 if (searchResultRow != null)
                 {
-                    form.ppidElement.controller.DisplayFault();
+                    form.ppidElement.controller.DisplayFault("Participant ID already exists!");
                     throw new Exception("Participant ID already exists! Enter a new ID or select the existing participant from the dropdown.");
                 }
                 // else new id has been entered


### PR DESCRIPTION
- Use in errors while setting participant details, like blank or duplicate ID
- Mainly to display error message/context in the UI instead of only in the console
- Increase error timeout from 5 to 8 seconds, since time required to read error message
- All tests passed in Unity 2017.4