### PR TITLE
Fix bug causing missing prompt in standalone builds

### DIFF
--- a/Assets/UXF/Scripts/UI/UIController.cs
+++ b/Assets/UXF/Scripts/UI/UIController.cs
@@ -157,6 +157,7 @@ namespace UXF.UI
         {
             if (session == null) session = GetComponentInParent<Session>();
             if (canvas == null) canvas = GetComponent<Canvas>();
+            if (popupController == null) popupController = GetComponentInChildren<PopupController>(true);
             // read word list
             if (uuidWordList) words = uuidWordList.text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             GenerateSidebar();


### PR DESCRIPTION
In standalone builds, there was a problem where trying to begin a session with a session number that already exists wouldn't prompt the experimenter with the 'This session already exists' popup. It would work in the editor since the popupController would get created in the OnValidate method of the UIController, but no such check/creation existed in the Awake method. After testing this change in both the editor and a standalone build, things seem to be working properly.