### PR TITLE
Avoid writing empty UXFDataTables

### DIFF
--- a/Assets/UXF/Scripts/Etc/Trial.cs
+++ b/Assets/UXF/Scripts/Etc/Trial.cs
@@ -264,7 +264,10 @@ namespace UXF
                 try
                 {
                     tracker.StopRecording();
-                    SaveDataTable(tracker.Data, tracker.DataName, dataType: UXFDataType.Trackers);
+                    if (tracker.Data.CountRows() > 0)
+                    {
+                        SaveDataTable(tracker.Data, tracker.DataName, dataType: UXFDataType.Trackers);
+                    }
                 }
                 catch (NullReferenceException)
                 {


### PR DESCRIPTION
This PR adds a check to avoid creating empty tracker files. 