### PR TITLE
Adding OnBlockBegin and OnBlockEnd UnityEvents

### DIFF
--- a/Assets/UXF/Scripts/Etc/Editor/SessionEditor.cs
+++ b/Assets/UXF/Scripts/Etc/Editor/SessionEditor.cs
@@ -108,7 +108,11 @@ namespace UXF.EditorUtils
 
                     EditorGUILayout.Space();
                     EditorGUILayout.HelpBox(GetTooltip(session.GetType().GetField("onSessionBegin")).tooltip, MessageType.Info);
-                    DrawPropertiesFromUpTo("onSessionBegin", "onTrialBegin");
+                    DrawPropertiesFromUpTo("onSessionBegin", "onBlockBegin");
+
+                    EditorGUILayout.Space();
+                    EditorGUILayout.HelpBox(GetTooltip(session.GetType().GetField("onBlockBegin")).tooltip, MessageType.Info);
+                    DrawPropertiesFromUpTo("onBlockBegin", "onTrialBegin");
 
                     EditorGUILayout.Space();
                     EditorGUILayout.HelpBox(GetTooltip(session.GetType().GetField("onTrialBegin")).tooltip, MessageType.Info);
@@ -116,7 +120,11 @@ namespace UXF.EditorUtils
 
                     EditorGUILayout.Space();
                     EditorGUILayout.HelpBox(GetTooltip(session.GetType().GetField("onTrialEnd")).tooltip, MessageType.Info);
-                    DrawPropertiesFromUpTo("onTrialEnd", "preSessionEnd");
+                    DrawPropertiesFromUpTo("onTrialEnd", "onBlockEnd");
+
+                    EditorGUILayout.Space();
+                    EditorGUILayout.HelpBox(GetTooltip(session.GetType().GetField("onBlockEnd")).tooltip, MessageType.Info);
+                    DrawPropertiesFromUpTo("onBlockEnd", "preSessionEnd");
 
                     EditorGUILayout.Space();
                     EditorGUILayout.HelpBox(GetTooltip(session.GetType().GetField("preSessionEnd")).tooltip, MessageType.Info);

--- a/Assets/UXF/Scripts/Etc/Events.cs
+++ b/Assets/UXF/Scripts/Etc/Events.cs
@@ -16,6 +16,15 @@ namespace UXF
     }
 
     /// <summary>
+    /// Event containing a Block as a parameter
+    /// </summary>
+    [Serializable]
+    public class BlockEvent : UnityEvent<Block>
+    {
+
+    }
+
+    /// <summary>
     /// Event containing a Trial as a parameter
     /// </summary>
     [Serializable]

--- a/Assets/UXF/Scripts/Etc/Trial.cs
+++ b/Assets/UXF/Scripts/Etc/Trial.cs
@@ -122,7 +122,7 @@ namespace UXF
 
             if (this == block.firstTrial)
             {
-                // call block on begin event
+                session.onBlockBegin.Invoke(block);
             }
 
             session.onTrialBegin.Invoke(this);
@@ -146,7 +146,7 @@ namespace UXF
 
             if (this == block.lastTrial)
             {
-                // call block on end event
+                session.onBlockEnd.Invoke(block);
             }
         }
 

--- a/Assets/UXF/Scripts/Etc/Trial.cs
+++ b/Assets/UXF/Scripts/Etc/Trial.cs
@@ -119,6 +119,12 @@ namespace UXF
                     Utilities.UXFDebugLogWarning("An item in the Tracked Objects field of the UXF session if empty (null)!");
                 }
             }
+
+            if (this == block.firstTrial)
+            {
+                // call block on begin event
+            }
+
             session.onTrialBegin.Invoke(this);
         }
 
@@ -137,6 +143,11 @@ namespace UXF
             }
 
             session.onTrialEnd.Invoke(this);
+
+            if (this == block.lastTrial)
+            {
+                // call block on end event
+            }
         }
 
         public bool CheckDataTypeIsValid(string dataName, UXFDataType dataType)

--- a/Assets/UXF/Scripts/Session.cs
+++ b/Assets/UXF/Scripts/Session.cs
@@ -94,6 +94,13 @@ namespace UXF
         public SessionEvent onSessionBegin = new SessionEvent();
 
         /// <summary>
+        /// Event(s) to trigger when a block begins. Can pass the instance of the Block as a dynamic argument
+        /// </summary>
+        /// <returns></returns>
+        [Tooltip("Items in this event will be triggered each time a block begins.")]
+        public BlockEvent onBlockBegin = new BlockEvent();
+
+        /// <summary>
         /// Event(s) to trigger when a trial begins. Can pass the instance of the Trial as a dynamic argument
         /// </summary>
         /// <returns></returns>
@@ -106,6 +113,13 @@ namespace UXF
         /// <returns></returns>
         [Tooltip("Items in this event will be triggered each time a trial ends. Useful for collecting results from the trial as well as showing feedback.")]
         public TrialEvent onTrialEnd = new TrialEvent();
+
+        /// <summary>
+        /// Event(s) to trigger when a block ends. Can pass the instance of the Block as a dynamic argument
+        /// </summary>
+        /// <returns></returns>
+        [Tooltip("Items in this event will be triggered each time a block ends.")]
+        public BlockEvent onBlockEnd = new BlockEvent();
 
         /// <summary>
         /// Event(s) to trigger just before the session has ended. If you wish to perform any summary statistics or write any final session data this is the time to do it. Do not use this event to quit the application.

--- a/Assets/UXF/Scripts/Session.cs
+++ b/Assets/UXF/Scripts/Session.cs
@@ -486,15 +486,17 @@ namespace UXF
         Trial GetLastTrial()
         {
             if (blocks.Count == 0) throw new NoSuchTrialException("There is no last trial because no blocks have been created!");
-            
+
             Block lastValidBlock;
+            Trial lastTrial;
             int i = blocks.Count - 1;
             while (i >= 0)
             {
                 lastValidBlock = blocks[i];
-                if (lastValidBlock.trials.Count > 0)
+                lastTrial = lastValidBlock.lastTrial;
+                if (lastTrial != null)
                 {
-                    return lastValidBlock.trials[lastValidBlock.trials.Count - 1];
+                    return lastTrial;
                 }
                 i--;
             }


### PR DESCRIPTION
This PR adds onBlockBegin and onBlockEnd UnityEvents. Fix #141 

Sneak hotfix:
- [Session.GetLastTrial uses Block.lastTrial](https://github.com/immersivecognition/unity-experiment-framework/commit/4d64bcf5d225d07600c69f4ab0e2440a234da357). I was trying something else. Left this in as it seemed cleaner.