### PR TITLE
Avoid overwriting by moving old file to backup

### DIFF
--- a/Assets/UXF/Scripts/DataHandling/FileSaver.cs
+++ b/Assets/UXF/Scripts/DataHandling/FileSaver.cs
@@ -1,11 +1,8 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Events;
 using System;
 using System.IO;
 using System.Threading;
-using System.Linq;
 using System.Globalization;
 
 namespace UXF
@@ -33,6 +30,16 @@ namespace UXF
         public bool verboseDebug = false;
 
         /// <summary>
+        /// Enable backing up the session directory if it already exists when a session starts.  If
+        /// not true, this will overwrite the is the UXF runs with the same experiment name, ppid,
+        /// and session number again.
+        /// </summary>
+        [Tooltip("Enable backing up the session directory if it already exists when a session starts.  If" +
+                 "not true, this will overwrite the is the UXF runs with the same experiment name, ppid," +
+                 "and session number again.")]
+        public bool backupSessionIfExists = true;
+
+        /// <summary>
         /// An action which does nothing.
         /// </summary>
         /// <returns></returns>
@@ -46,7 +53,6 @@ namespace UXF
 
         bool quitting = false;
 
-
         /// <summary>
         /// Starts the FileSaver Worker thread.
         /// </summary>
@@ -59,6 +65,37 @@ namespace UXF
 
             quitting = false;
             Directory.CreateDirectory(base.StoragePath);
+            string sessionDirectory = GetSessionPath(session.experimentName, session.ppid, session.number);
+            if (Directory.Exists(sessionDirectory))
+            {
+                Utilities.UXFDebugLogWarning($"Session directory {sessionDirectory} already exists.");
+                if (backupSessionIfExists)
+                {
+                    string suffix = Directory.GetLastWriteTime(sessionDirectory).ToString("dd-MM-yyyy-HH-mm-FF");
+                    string backupSessionDirectory = $"{sessionDirectory}_{suffix}";
+
+                    int idx = 1;
+                    while (Directory.Exists(backupSessionDirectory))
+                    {
+                        backupSessionDirectory = $"{backupSessionDirectory}_{idx}";
+                    }
+
+                    try
+                    {
+                        Directory.Move(sessionDirectory, backupSessionDirectory);
+                        Utilities.UXFDebugLogWarning($"Trying to backup {sessionDirectory} to {backupSessionDirectory}.");
+                    }
+                    catch(Exception e)
+                    {
+                        Utilities.UXFDebugLogError($"Failed to backup {sessionDirectory} to {backupSessionDirectory} with exception ({e}): {e.Message}");
+                        throw e;
+                    }
+                }
+                else
+                {
+                    Utilities.UXFDebugLogWarning($"backupSessionIfExists is False. Content in {sessionDirectory} may be overwritten.");
+                }
+            }
 
             if (!IsActive)
             {

--- a/Assets/UXF/Tests/Editor/TestFileIOManager.cs
+++ b/Assets/UXF/Tests/Editor/TestFileIOManager.cs
@@ -11,6 +11,7 @@ namespace UXF.Tests
         string ppid = "test_ppid";
         int sessionNum = 1;
         FileSaver fileSaver;
+        Session session;
 
         [SetUp]
         public void SetUp()
@@ -18,6 +19,12 @@ namespace UXF.Tests
             var gameObject = new GameObject();
             fileSaver = gameObject.AddComponent<FileSaver>();
             fileSaver.verboseDebug = true;
+            if (Session.instance != null) GameObject.DestroyImmediate(Session.instance.gameObject);
+            session = gameObject.AddComponent<Session>();
+            session.experimentName = "test_experiment";
+            session.ppid = "P001";
+            session.number = 1;
+            fileSaver.Initialise(session);
         }
 
 
@@ -149,5 +156,80 @@ namespace UXF.Tests
                 SystemInfo.operatingSystemFamily == OperatingSystemFamily.Windows ? "123" : "../123" 
             );
         }
+
+        [Test]
+        public void TestBackupSession()
+        {
+            fileSaver.StoragePath = "test_output";
+            fileSaver.backupSessionIfExists = true;
+            if (Directory.Exists(fileSaver.StoragePath))
+            {
+                Directory.Delete(fileSaver.StoragePath, true);
+            }
+
+            fileSaver.SetUp();
+
+            string fileName = "testMoveToBackup";
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+
+            fileSaver.CleanUp();
+            System.Threading.Thread.Sleep(500);
+
+            fileSaver.SetUp();
+
+            fileName = "testMoveToBackup";
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+
+            fileSaver.CleanUp();
+
+            string testFilesDirectory = fileSaver.GetSessionPath(session.experimentName, session.ppid, session.number);
+
+            string[] directories = Directory.GetDirectories(Directory.GetParent(testFilesDirectory).ToString(), $"{FileSaver.SessionNumToName(1)}*", SearchOption.TopDirectoryOnly);
+            Assert.AreEqual(directories.Length, 2);
+
+            Directory.Delete(fileSaver.StoragePath, true);
+        }
+
+        [Test]
+        public void TestSessionOverwrite()
+        {
+            fileSaver.StoragePath = "test_output";
+            fileSaver.backupSessionIfExists = false;
+            if (Directory.Exists(fileSaver.StoragePath))
+            {
+                Directory.Delete(fileSaver.StoragePath, true);
+            }
+
+            fileSaver.SetUp();
+
+            string fileName = "testMoveToBackup";
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+
+            fileSaver.CleanUp();
+            System.Threading.Thread.Sleep(500);
+
+            fileSaver.SetUp();
+
+            fileName = "testMoveToBackup";
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+            fileSaver.HandleText("", session.experimentName, session.ppid, session.number, fileName, UXFDataType.TrialResults);
+
+            fileSaver.CleanUp();
+
+            string testFilesDirectory = fileSaver.GetSessionPath(session.experimentName, session.ppid, session.number);
+
+            string[] directories = Directory.GetDirectories(Directory.GetParent(testFilesDirectory).ToString(), $"{FileSaver.SessionNumToName(1)}*", SearchOption.TopDirectoryOnly);
+            Assert.AreEqual(directories.Length, 1);
+
+            Directory.Delete(fileSaver.StoragePath, true);
+        }
     }
+
 }


### PR DESCRIPTION
This PR ensures the FileSaver doesn't overwrite any existing files. It creates a backup of a file about to be overwritten with it's last written time as a suffix.