### PR TITLE
Fixing incorrect `delayCall` callback registrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ $RECYCLE.BIN/
 
 # Visual Studio Code project
 .vscode/*
+.idea/*
 example_output/*
 
 Assets/MyAWSCredentials.asset*

--- a/Assets/UXF/Scripts/Etc/ReorderableInspector/Editor/ReorderableArrayInspector.cs
+++ b/Assets/UXF/Scripts/Etc/ReorderableInspector/Editor/ReorderableArrayInspector.cs
@@ -62,7 +62,7 @@ namespace SubjectNerd.Utilities
 		{
 			FORCE_INIT = true;
 
-			EditorApplication.delayCall = () => { EditorApplication.delayCall = () => { FORCE_INIT = false; }; };
+			EditorApplication.delayCall += () => { EditorApplication.delayCall += () => { FORCE_INIT = false; }; };
 		}
 
 		private static GUIStyle styleHighlight;


### PR DESCRIPTION
In recent Unity changes to the Scene view shortcuts, they register a method to this callback to set up the contexts of navigation shortcuts (such as WASD movement). Incorrect registrations in the code-base essentially break any form of movement in Scene view. (See: UUM-73924)

This bugfix resolves the broken Scene view controls for these versions: 2022.3.14f1, 2022.3.33f1, 6000.0.6f1

Fixes #164 