### PR TITLE
Chore: Added Unity 6 support with backward compatibility

### DIFF
--- a/Assets/UXF/Examples/3_MultiScene_FootballAndRT/Scripts/Example_MultiSceneExperimentGenerator.cs
+++ b/Assets/UXF/Examples/3_MultiScene_FootballAndRT/Scripts/Example_MultiSceneExperimentGenerator.cs
@@ -77,11 +77,19 @@ namespace UXFExamples
 			// there are lots of ways to do this, but this works fine here
 			if (trial.block.number == 1)
 			{
+#if UNITY_6000
+				FindFirstObjectByType<Example_ShootingTask>().StartShootingTaskTrial(trial);
+#else
 				FindObjectOfType<Example_ShootingTask>().StartShootingTaskTrial(trial);
+#endif
 			}
 			else if (trial.block.number == 2)
 			{
+#if UNITY_6000
+				FindFirstObjectByType<Example_ReactionTask>().StartReactionTaskTrial(trial);
+#else
 				FindObjectOfType<Example_ReactionTask>().StartReactionTaskTrial(trial);
+#endif
 			}
 		}
 
@@ -94,11 +102,19 @@ namespace UXFExamples
 			// there are lots of ways to do this, but this works fine here
 			if (trial.block.number == 1)
 			{
+#if UNITY_6000
+				FindFirstObjectByType<Example_ShootingTask>().EndShootingTaskTrial(trial);
+#else
 				FindObjectOfType<Example_ShootingTask>().EndShootingTaskTrial(trial);
+#endif
 			}
 			else if (trial.block.number == 2)
 			{
+#if UNITY_6000
+				FindFirstObjectByType<Example_ReactionTask>().EndReactionTaskTrial(trial);
+#else
 				FindObjectOfType<Example_ReactionTask>().EndReactionTaskTrial(trial);
+#endif
 			}
 		}
 

--- a/Assets/UXF/Examples/3_MultiScene_FootballAndRT/Scripts/Example_Shooter.cs
+++ b/Assets/UXF/Examples/3_MultiScene_FootballAndRT/Scripts/Example_Shooter.cs
@@ -51,7 +51,11 @@ namespace UXFExamples
                     // launch when clicked
                     if (Input.GetMouseButtonDown(0))
                     {
+#if UNITY_6000
+                        ball.linearVelocity = launchVelocity;
+#else
                         ball.velocity = launchVelocity;
+#endif
                         canShoot = false;
 
                         // only have a certain time to score, or its classified as a miss!

--- a/Assets/UXF/Scripts/DataHandling/WebAWSDynamoDB.cs
+++ b/Assets/UXF/Scripts/DataHandling/WebAWSDynamoDB.cs
@@ -466,7 +466,9 @@ namespace UXF
             {
                 case UnityEditor.BuildTargetGroup.Android:
                 case UnityEditor.BuildTargetGroup.iOS:
+#if !UNITY_2022_2_OR_NEWER
                 case UnityEditor.BuildTargetGroup.Lumin:
+#endif
                 case UnityEditor.BuildTargetGroup.PS4:
                 case UnityEditor.BuildTargetGroup.Switch:
                 case UnityEditor.BuildTargetGroup.tvOS:

--- a/Assets/UXF/Scripts/EventSystemFallback.cs
+++ b/Assets/UXF/Scripts/EventSystemFallback.cs
@@ -28,7 +28,11 @@ namespace UXF
 
         void CreateEventSystem()
         {
+#if UNITY_6000
+            if (FindFirstObjectByType<EventSystem>() == null)
+#else
             if (FindObjectOfType<EventSystem>() == null)
+#endif
             {
                 var newEventSystem = Instantiate(eventSystemPrefab);
                 newEventSystem.name = "EventSystem";


### PR DESCRIPTION
Used preprocessor directives. 
Tested with Unity 6000.0.31f1 and Unity 2022.3.9f1.
No warnings show up on the console when launching or importing the project.
This also addresses the [lack of Lumin post 2022.2](https://discussions.unity.com/t/linking-lumin-sdk-to-unity/782774/5)

Addresses #171 and #172 