### PR TITLE
Add multithreading for saving tracker data

### DIFF
--- a/Assets/UXF/Scripts/Etc/ResultsDict.cs
+++ b/Assets/UXF/Scripts/Etc/ResultsDict.cs
@@ -13,6 +13,7 @@ namespace UXF
     {
         private Dictionary<string, object> baseDict;
         private bool allowAdHocAdding;
+        private Object lockObject = new Object();
 
         /// <summary>
         /// Dictionary of results for a trial.
@@ -25,7 +26,10 @@ namespace UXF
             this.allowAdHocAdding = allowAdHocAdding;
             foreach (var key in initialKeys)
             {
-                baseDict.Add(key, string.Empty);
+                lock (lockObject)
+                {
+                    baseDict.Add(key, string.Empty);
+                }
             }
         }
 
@@ -38,13 +42,16 @@ namespace UXF
         {
             get { return baseDict[key]; }
             set {
-                if (allowAdHocAdding || baseDict.ContainsKey(key))
+                lock (lockObject)
                 {
-                    baseDict[key] = value;
-                }
-                else
-                {
-                    throw new KeyNotFoundException(string.Format("Custom header \"{0}\" does not exist!", key));
+                    if (allowAdHocAdding || baseDict.ContainsKey(key))
+                    {
+                        baseDict[key] = value;
+                    }
+                    else
+                    {
+                        throw new KeyNotFoundException(string.Format("Custom header \"{0}\" does not exist!", key));
+                    }
                 }
             }
         }

--- a/Assets/UXF/Scripts/Session.cs
+++ b/Assets/UXF/Scripts/Session.cs
@@ -695,6 +695,8 @@ namespace UXF
 
         void SaveResults()
         {
+            Trial.WaitForTasks();
+
             // generate list of all headers possible
             // hashset keeps unique set of keys
             HashSet<string> resultsHeaders = new HashSet<string>();


### PR DESCRIPTION
Fix #163
This includes the fix I mentioned in #163. This adds multithreading when saving data. This becomes an issue when large amounts of data is being written out, where the methods in SaveData do a lot of string processing. To ensure data is correctly written out, this also waits for the threads to complete when the session is ending.